### PR TITLE
add --runtime_link option

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,5 +1,6 @@
 {
   "variables": {
+    "runtime_link%":"shared",
     "node_gdal_sources": [
       "src/node_gdal.cpp",
       "src/gdal_dataset.cpp",
@@ -25,6 +26,11 @@
       ],
       "libraries": [
         "<!@(gdal-config --libs)"
+      ],
+      "conditions": [
+           ["runtime_link == 'static'", {
+              'libraries': ['<!@(gdal-config --dep-libs)']
+          }]
       ],
       "cflags": [
         "<!@(gdal-config --cflags)"


### PR DESCRIPTION
This adds a `runtime_link` variable to `binding.gyp`. This makes it possible to do `npm install gdal --runtime_link=static` which triggers not only `-lgdal` to be linked but also all libs that libgdal depends upon.

This is obscure but needed on my end because I usually use a `libgdal.a` with all dependent libraries statically linked. In this case without also linking the libs gdal depends you'll see this type of error on startup:

```
$ node examples/rasterinfo.js 

module.js:356
  Module._extensions[extension](this, filename);
                               ^
Error: dlopen(/Users/dane/projects/node-gdal/build/Release/gdal.node, 1): Symbol not found: _jpeg_resync_to_restart
  Referenced from: /Users/dane/projects/node-gdal/build/Release/gdal.node
  Expected in: flat namespace
 in /Users/dane/projects/node-gdal/build/Release/gdal.node
```

This is the same approach taken in `node-srs`: https://github.com/mapbox/node-srs/blob/fad86bd06f1bcd49492a057de71b28d5c9042c98/binding.gyp#L4
