### PR TITLE
More chai assert methods for nicer failure messages

### DIFF
--- a/test/dataset.test.js
+++ b/test/dataset.test.js
@@ -12,7 +12,7 @@ describe('Dataset', function() {
 	it('should not be instantiable', function() {
 		assert.throws(function() {
 			new gdal.Dataset();
-		});
+		}, /Cannot create dataset directly/);
 	});
 
 	describe('getProjectionRef()', function() {
@@ -35,7 +35,7 @@ describe('Dataset', function() {
 			var ds = gdal.open(__dirname + "/data/sample.tif");
 			assert.throws(function() {
 				ds.setProjection('`1`inoinawfawfian!@121');
-			});
+			}, /not supported/);
 		});
 		it('should set projection (WKT)', function() {
 			var file_orig = __dirname + "/data/dem_azimuth50_pa.img";
@@ -82,7 +82,7 @@ describe('Dataset', function() {
 		});
 		it('should return RasterBand instance when valid band', function() {
 			var band = ds.getRasterBand(1);
-			assert.ok(band instanceof gdal.RasterBand);
+			assert.instanceOf(band, gdal.RasterBand);
 		});
 	});
 

--- a/test/open.test.js
+++ b/test/open.test.js
@@ -9,6 +9,6 @@ describe('Open', function() {
 		var filename = path.join(__dirname,"data/invalid");
 		assert.throws(function() {
 			gdal.open(filename);
-		});
+		}, /Error opening dataset/);
 	});
 });

--- a/test/open_gtiff.test.js
+++ b/test/open_gtiff.test.js
@@ -2,7 +2,7 @@
 
 var gdal = require('../lib/gdal.js');
 var path = require('path');
-var assert = require('assert');
+var assert = require('chai').assert;
 
 describe('Open', function() {
 	describe('TIFF', function() {
@@ -30,12 +30,13 @@ describe('Open', function() {
 			];
 
 			var actual_geotransform = ds.getGeoTransform();
-			assert.ok(Math.abs(actual_geotransform[0] - expected_geotransform[0]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[1] - expected_geotransform[1]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[2] - expected_geotransform[2]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[3] - expected_geotransform[3]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[4] - expected_geotransform[4]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[5] - expected_geotransform[5]) < .00001);
+			var delta = .00001;
+			assert.closeTo(actual_geotransform[0], expected_geotransform[0], delta);
+			assert.closeTo(actual_geotransform[1], expected_geotransform[1], delta);
+			assert.closeTo(actual_geotransform[2], expected_geotransform[2], delta);
+			assert.closeTo(actual_geotransform[3], expected_geotransform[3], delta);
+			assert.closeTo(actual_geotransform[4], expected_geotransform[4], delta);
+			assert.closeTo(actual_geotransform[5], expected_geotransform[5], delta);
 		});
 
 		it('should be able to read statistics', function() {
@@ -50,10 +51,11 @@ describe('Open', function() {
 			};
 
 			var actual_stats = band.getStatistics(false, true);
-			assert.ok(Math.abs(expected_stats.min - actual_stats.min) < .00001);
-			assert.ok(Math.abs(expected_stats.max - actual_stats.max) < .00001);
-			assert.ok(Math.abs(expected_stats.mean - actual_stats.mean) < .00001);
-			assert.ok(Math.abs(expected_stats.std_dev - actual_stats.std_dev) < .00001);
+			var delta = .00001;
+			assert.closeTo(actual_stats.min, expected_stats.min, delta);
+			assert.closeTo(actual_stats.max, expected_stats.max, delta);
+			assert.closeTo(actual_stats.mean, expected_stats.mean, delta);
+			assert.closeTo(actual_stats.std_dev, expected_stats.std_dev, delta);
 		});
 	});
 });

--- a/test/open_hfa.test.js
+++ b/test/open_hfa.test.js
@@ -2,7 +2,7 @@
 
 var gdal = require('../lib/gdal.js');
 var path = require('path');
-var assert = require('assert');
+var assert = require('chai').assert;
 
 describe('Open', function() {
 	describe('HFA (IMG)', function() {
@@ -23,12 +23,13 @@ describe('Open', function() {
 			var expected_geotransform = [-215000, 1000, 0, 365000, 0, -1000];
 
 			var actual_geotransform = ds.getGeoTransform();
-			assert.ok(Math.abs(actual_geotransform[0] - expected_geotransform[0]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[1] - expected_geotransform[1]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[2] - expected_geotransform[2]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[3] - expected_geotransform[3]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[4] - expected_geotransform[4]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[5] - expected_geotransform[5]) < .00001);
+			var delta = .00001;
+			assert.closeTo(actual_geotransform[0], expected_geotransform[0], delta);
+			assert.closeTo(actual_geotransform[1], expected_geotransform[1], delta);
+			assert.closeTo(actual_geotransform[2], expected_geotransform[2], delta);
+			assert.closeTo(actual_geotransform[3], expected_geotransform[3], delta);
+			assert.closeTo(actual_geotransform[4], expected_geotransform[4], delta);
+			assert.closeTo(actual_geotransform[5], expected_geotransform[5], delta);
 		});
 
 		it('should be able to read statistics', function() {
@@ -44,10 +45,11 @@ describe('Open', function() {
 			};
 
 			var actual_stats = band.getStatistics(false, true);
-			assert.ok(Math.abs(expected_stats.min - actual_stats.min) < .00001);
-			assert.ok(Math.abs(expected_stats.max - actual_stats.max) < .00001);
-			assert.ok(Math.abs(expected_stats.mean - actual_stats.mean) < .00001);
-			assert.ok(Math.abs(expected_stats.std_dev - actual_stats.std_dev) < .00001);
+			var delta = .00001;
+			assert.closeTo(actual_stats.min, expected_stats.min, delta);
+			assert.closeTo(actual_stats.max, expected_stats.max, delta);
+			assert.closeTo(actual_stats.mean, expected_stats.mean, delta);
+			assert.closeTo(actual_stats.std_dev, expected_stats.std_dev, delta);
 		});
 	});
 });

--- a/test/open_jpg.test.js
+++ b/test/open_jpg.test.js
@@ -3,7 +3,6 @@
 var gdal = require('../lib/gdal.js');
 var path = require('path');
 var assert = require('chai').assert;
-var expect = require('chai').expect;
 
 describe('Open', function() {
 	describe('JPG', function() {
@@ -31,12 +30,13 @@ describe('Open', function() {
 			];
 
 			var actual_geotransform = ds.getGeoTransform();
-			assert.ok(Math.abs(actual_geotransform[0] - expected_geotransform[0]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[1] - expected_geotransform[1]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[2] - expected_geotransform[2]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[3] - expected_geotransform[3]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[4] - expected_geotransform[4]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[5] - expected_geotransform[5]) < .00001);
+			var delta = .00001;
+			assert.closeTo(actual_geotransform[0], expected_geotransform[0], delta);
+			assert.closeTo(actual_geotransform[1], expected_geotransform[1], delta);
+			assert.closeTo(actual_geotransform[2], expected_geotransform[2], delta);
+			assert.closeTo(actual_geotransform[3], expected_geotransform[3], delta);
+			assert.closeTo(actual_geotransform[4], expected_geotransform[4], delta);
+			assert.closeTo(actual_geotransform[5], expected_geotransform[5], delta);
 		});
 
 		it('should be able to read statistics', function() {
@@ -52,10 +52,11 @@ describe('Open', function() {
 			};
 
 			var actual_stats = band.getStatistics(false, true);
-			assert.ok(Math.abs(expected_stats.min - actual_stats.min) < .00001);
-			assert.ok(Math.abs(expected_stats.max - actual_stats.max) < .00001);
-			assert.ok(Math.abs(expected_stats.mean - actual_stats.mean) < .00001);
-			assert.ok(Math.abs(expected_stats.std_dev - actual_stats.std_dev) < .00001);
+			var delta = .00001;
+			assert.closeTo(actual_stats.min, expected_stats.min, delta);
+			assert.closeTo(actual_stats.max, expected_stats.max, delta);
+			assert.closeTo(actual_stats.mean, expected_stats.mean, delta);
+			assert.closeTo(actual_stats.std_dev, expected_stats.std_dev, delta);
 		});
 
 		it('should be able to read block size', function() {
@@ -75,8 +76,7 @@ describe('Open', function() {
 			var actual_files = ds.getFileList();
 			actual_files.sort();
 			files.sort();
-
-			expect(actual_files).to.eql(files);
+			assert.deepEqual(actual_files, files);
 		});
 	});
 });

--- a/test/open_png.test.js
+++ b/test/open_png.test.js
@@ -3,7 +3,6 @@
 var gdal = require('../lib/gdal.js');
 var path = require('path');
 var assert = require('chai').assert;
-var expect = require('chai').expect;
 
 describe('Open', function() {
 	describe('PNG', function() {
@@ -31,12 +30,13 @@ describe('Open', function() {
 			];
 
 			var actual_geotransform = ds.getGeoTransform();
-			assert.ok(Math.abs(actual_geotransform[0] - expected_geotransform[0]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[1] - expected_geotransform[1]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[2] - expected_geotransform[2]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[3] - expected_geotransform[3]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[4] - expected_geotransform[4]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[5] - expected_geotransform[5]) < .00001);
+			var delta = .00001;
+			assert.closeTo(actual_geotransform[0], expected_geotransform[0], delta);
+			assert.closeTo(actual_geotransform[1], expected_geotransform[1], delta);
+			assert.closeTo(actual_geotransform[2], expected_geotransform[2], delta);
+			assert.closeTo(actual_geotransform[3], expected_geotransform[3], delta);
+			assert.closeTo(actual_geotransform[4], expected_geotransform[4], delta);
+			assert.closeTo(actual_geotransform[5], expected_geotransform[5], delta);
 		});
 
 		it('should be able to read statistics', function() {
@@ -52,10 +52,11 @@ describe('Open', function() {
 			};
 
 			var actual_stats = band.getStatistics(false, true);
-			assert.ok(Math.abs(expected_stats.min - actual_stats.min) < .00001);
-			assert.ok(Math.abs(expected_stats.max - actual_stats.max) < .00001);
-			assert.ok(Math.abs(expected_stats.mean - actual_stats.mean) < .00001);
-			assert.ok(Math.abs(expected_stats.std_dev - actual_stats.std_dev) < .00001);
+			var delta = .00001;
+			assert.closeTo(actual_stats.min, expected_stats.min, delta);
+			assert.closeTo(actual_stats.max, expected_stats.max, delta);
+			assert.closeTo(actual_stats.mean, expected_stats.mean, delta);
+			assert.closeTo(actual_stats.std_dev, expected_stats.std_dev, delta);
 		});
 
 		it('should be able to read block size', function() {
@@ -76,7 +77,7 @@ describe('Open', function() {
 			actual_files.sort();
 			files.sort();
 
-			expect(actual_files).to.eql(files);
+			assert.deepEqual(actual_files, files);
 		});
 	});
 });

--- a/test/open_sdts.test.js
+++ b/test/open_sdts.test.js
@@ -2,7 +2,7 @@
 
 var gdal = require('../lib/gdal.js');
 var path = require('path');
-var assert = require('assert');
+var assert = require('chai').assert;
 
 describe('Open', function() {
 	describe('SDTS (DDF)', function() {
@@ -30,12 +30,13 @@ describe('Open', function() {
 			];
 
 			var actual_geotransform = ds.getGeoTransform();
-			assert.ok(Math.abs(actual_geotransform[0] - expected_geotransform[0]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[1] - expected_geotransform[1]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[2] - expected_geotransform[2]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[3] - expected_geotransform[3]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[4] - expected_geotransform[4]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[5] - expected_geotransform[5]) < .00001);
+			var delta = .00001;
+			assert.closeTo(actual_geotransform[0], expected_geotransform[0], delta);
+			assert.closeTo(actual_geotransform[1], expected_geotransform[1], delta);
+			assert.closeTo(actual_geotransform[2], expected_geotransform[2], delta);
+			assert.closeTo(actual_geotransform[3], expected_geotransform[3], delta);
+			assert.closeTo(actual_geotransform[4], expected_geotransform[4], delta);
+			assert.closeTo(actual_geotransform[5], expected_geotransform[5], delta);
 		});
 
 		it('should be able to read statistics', function() {
@@ -50,10 +51,11 @@ describe('Open', function() {
 			};
 
 			var actual_stats = band.getStatistics(false, true);
-			assert.ok(Math.abs(expected_stats.min - actual_stats.min) < .00001);
-			assert.ok(Math.abs(expected_stats.max - actual_stats.max) < .00001);
-			assert.ok(Math.abs(expected_stats.mean - actual_stats.mean) < .00001);
-			assert.ok(Math.abs(expected_stats.std_dev - actual_stats.std_dev) < .00001);
+			var delta = .00001;
+			assert.closeTo(expected_stats.min, actual_stats.min, delta);
+			assert.closeTo(expected_stats.max, actual_stats.max, delta);
+			assert.closeTo(expected_stats.mean, actual_stats.mean, delta);
+			assert.closeTo(expected_stats.std_dev, actual_stats.std_dev, delta);
 		});
 	});
 });

--- a/test/open_vrt.test.js
+++ b/test/open_vrt.test.js
@@ -2,7 +2,7 @@
 
 var gdal = require('../lib/gdal.js');
 var path = require('path');
-var assert = require('assert');
+var assert = require('chai').assert;
 
 describe('Open', function() {
 	describe('VRT', function() {
@@ -30,12 +30,13 @@ describe('Open', function() {
 			];
 
 			var actual_geotransform = ds.getGeoTransform();
-			assert.ok(Math.abs(actual_geotransform[0] - expected_geotransform[0]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[1] - expected_geotransform[1]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[2] - expected_geotransform[2]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[3] - expected_geotransform[3]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[4] - expected_geotransform[4]) < .00001);
-			assert.ok(Math.abs(actual_geotransform[5] - expected_geotransform[5]) < .00001);
+			var delta = .00001;
+			assert.closeTo(actual_geotransform[0], expected_geotransform[0], delta);
+			assert.closeTo(actual_geotransform[1], expected_geotransform[1], delta);
+			assert.closeTo(actual_geotransform[2], expected_geotransform[2], delta);
+			assert.closeTo(actual_geotransform[3], expected_geotransform[3], delta);
+			assert.closeTo(actual_geotransform[4], expected_geotransform[4], delta);
+			assert.closeTo(actual_geotransform[5], expected_geotransform[5], delta);
 		});
 
 		it('should be able to read statistics', function() {
@@ -50,10 +51,11 @@ describe('Open', function() {
 			};
 
 			var actual_stats = band.getStatistics(false, true);
-			assert.ok(Math.abs(expected_stats.min - actual_stats.min) < .00001);
-			assert.ok(Math.abs(expected_stats.max - actual_stats.max) < .00001);
-			assert.ok(Math.abs(expected_stats.mean - actual_stats.mean) < .00001);
-			assert.ok(Math.abs(expected_stats.std_dev - actual_stats.std_dev) < .00001);
+			var delta = .00001;
+			assert.closeTo(actual_stats.min, expected_stats.min, delta);
+			assert.closeTo(actual_stats.max, expected_stats.max, delta);
+			assert.closeTo(actual_stats.mean, expected_stats.mean, delta);
+			assert.closeTo(actual_stats.std_dev, expected_stats.std_dev, delta);
 		});
 	});
 });


### PR DESCRIPTION
This is a bit trivial, but it makes failures even more descriptive (in the vein of 65ca74122782094cb0209e85e82984e94ed74f42).
