### PR TITLE
Guess: travis updated homebrew, update/uninstall no longer necessary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 
 install:
   - if [[ ${TARGET} == 'SHARED' ]] && [[ "$(uname -s)" == 'Linux' ]]; then sudo apt-get -qq update; sudo apt-get -qq install libgdal1-dev; fi;
-  - if [[ ${TARGET} == 'SHARED' ]] && [[ "$(uname -s)" == 'Darwin' ]]; then brew update && brew unlink gdal && brew install gdal; fi;
+  - if [[ ${TARGET} == 'SHARED' ]] && [[ "$(uname -s)" == 'Darwin' ]]; then brew install gdal; fi;
   - if [[ ${TARGET} == 'SHARED' ]]; then npm install --build-from-source --shared_gdal; fi;
   - if [[ ${TARGET} == 'STATIC' ]]; then npm install --build-from-source; fi;
   - npm test


### PR DESCRIPTION
Looks like Travis got their default brews up to speed so we don't need to do the update/uninstall/install gdal dance.

Refs #48.
