### PR TITLE
Avoid using pretest target in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     }
   ],
   "scripts": {
-    "pretest": "npm install --dev",
     "test": "mocha test -R tap --no-colors",
     "install": "node-pre-gyp install --fallback-to-build"
   },


### PR DESCRIPTION
/cc @brianreavis please merge if this looks good to you.

This `pretest` target is not necessary and due to npm's behavior of also trying to install the main module with `npm install --dev` it can create really odd behavior where the tests end up re-installing the module. I wish `npm install --dev` only installed the `devDependencies` but at this point I don't know a way to do that.

Refs https://github.com/naturalatlas/node-gdal/issues/54#issuecomment-50369013
