### PR TITLE
win: use consistent RuntimeLibrary - inherit from node

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -62,7 +62,6 @@
 					"VCCLCompilerTool": {
 						"ExceptionHandling": 2, # /EHsc
 						"RuntimeTypeInfo": "true",
-						"RuntimeLibrary": "2", # 0:/MT, 1:/MTd, 2:/MD, 3:/MDd
 						"DebugInformationFormat": "0"
 					},
 					"VCLinkerTool": {

--- a/deps/libgdal/common.gypi
+++ b/deps/libgdal/common.gypi
@@ -44,7 +44,6 @@
 			["OS == 'win'", {
 				"include_dirs": ["./arch/win"],
 				"VCCLCompilerTool": {
-					"RuntimeLibrary": "0", # 0:/MT, 1:/MTd, 2:/MD, 3:/MDd
 					"DebugInformationFormat": "0"
 				},
 				"VCLinkerTool": {


### PR DESCRIPTION
This fixes a mismatch I noticed in how libgdal is built vs the node bindings. In windows land things can go pear shaped when this happens. Because node's build system sets `/MT` removing both of these options will result in the entire build consistently using `/MT`.

Appveyor is backed up, but will plan to merge this once https://ci.appveyor.com/project/brianreavis/node-gdal/build/418 is green.
