### PR TITLE
Fix debug flags on OS X

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 			"Debug": {
 				"cflags_cc!": ["-O3", "-Os", "-DNDEBUG"],
 				"xcode_settings": {
-					"OTHER_CPLUSPLUSFLAGS": ["-O3", "-Os", "-DNDEBUG"],
+					"OTHER_CPLUSPLUSFLAGS": ["-DDEBUG"],
 					"GCC_OPTIMIZATION_LEVEL": "0",
 					"GCC_GENERATE_DEBUGGING_SYMBOLS": "YES"
 				},


### PR DESCRIPTION
This avoids setting optimization flags in debug mode.

Note: a trailing `!` in gyp syntax means to remove any flags rather than adding. So I presume at some point this said:

```js
"OTHER_CPLUSPLUSFLAGS!": ["-O3", "-Os", "-DNDEBUG"],
```

Which would have been fine. But the likelyhood of `-O3` or `-Os` or `-DNDEBUG` being already in the flags and needing removed is very small. Instead we can avoid trying to remove anything and just add `-DDEBUG`. The optimization is handled by `GCC_OPTIMIZATION_LEVEL`.
