### PR TITLE
Updated 'engines' field to limit installation to NodeJS versions <3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "node-pre-gyp"
   ],
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 0.8.0 <3.0.0"
   },
   "engineStrict": true
 }


### PR DESCRIPTION
Since node-gdal is currently incompatible with NodeJS 3.0+, prevent npm from installing node-gdal on NodeJS versions >=3.0.0.