### PR TITLE
Modify and test GDAL_DATA behavior

### DIFF
--- a/lib/gdal.js
+++ b/lib/gdal.js
@@ -1,8 +1,13 @@
 var path         = require('path');
+var fs           = require('fs');
 var pkg          = require('../package.json');
 var binding_path = path.join(__dirname, '../', pkg.binary.module_path);
 var module_path  = path.join(binding_path, pkg.binary.module_name + '.node');
 var data_path    = path.resolve(__dirname, '../deps/libgdal/gdal/data');
+
+if (process.env.GDAL_DATA === undefined && !fs.existsSync(data_path)) {
+	throw new Error("The bundled data path for node-gdal is missing '" + data_path + "' and GDAL_DATA environment is not set");
+}
 
 var gdal = module.exports = require(module_path);
 
@@ -49,7 +54,9 @@ gdal.config.set = gdal.setConfigOption;
 delete gdal.getConfigOption;
 delete gdal.setConfigOption;
 
-gdal.config.set('GDAL_DATA', data_path);
+if (process.env.GDAL_DATA === undefined) {
+	gdal.config.set('GDAL_DATA', data_path);
+}
 
 gdal.Envelope = require('./envelope.js')(gdal);
 gdal.Envelope3D = require('./envelope_3d.js')(gdal);

--- a/test/api_base.test.js
+++ b/test/api_base.test.js
@@ -3,6 +3,11 @@
 var gdal = require('../lib/gdal.js');
 var assert = require('chai').assert;
 var fs = require('fs');
+var path = require('path');
+
+if (process.env.GDAL_DATA !== undefined) {
+	throw new Error("Sorry, this test requires that the GDAL_DATA environment option is not set");
+}
 
 describe('gdal', function() {
 	afterEach(gc);
@@ -55,6 +60,22 @@ describe('gdal', function() {
 				assert.equal(gdal.config.get('CPL_DEBUG'), 'ON');
 				gdal.config.set('CPL_DEBUG', null);
 				assert.isNull(gdal.config.get('CPL_DEBUG'));
+			});
+		});
+		describe('GDAL_DATA behavior', function() {
+			var data_path = path.resolve(__dirname, '../deps/libgdal/gdal/data');
+			it('should set GDAL_DATA config option to locally bundled path', function() {
+				assert.equal(gdal.config.get('GDAL_DATA'),data_path);
+			});
+			it('should respect GDAL_DATA environment over locally bundled path', function(done) {
+				process.env.GDAL_DATA = 'bogus';
+				var cp = require('child_process');
+				var command = "\"var gdal = require('./lib/gdal.js'); console.log(gdal.config.get('GDAL_DATA'));\"";
+				cp.exec(process.execPath + ' ' + ['-e',command].join(' '),{env:{GDAL_DATA:'bogus'}},function(err,stdout,stderr) {
+					if (err) throw err;
+					assert.equal(process.env.GDAL_DATA,stdout.trim());
+					done();
+				})
 			});
 		});
 	});

--- a/test/api_base.test.js
+++ b/test/api_base.test.js
@@ -74,7 +74,7 @@ describe('gdal', function() {
 				var execPath = process.execPath;
 				if (process.platform === 'win32') {
 					// attempt to avoid quoting problem that leads to error like ''C:\Program' is not recognized as an internal or external command'
-					execPath = execPath.replace(/ /g, '\\ ');
+					execPath = '"' + execPath + '"';
 				}
 				cp.exec(execPath + ' ' + ['-e',command].join(' '),{env:{GDAL_DATA:'bogus'}},function(err,stdout,stderr) {
 					if (err) throw err;

--- a/test/api_base.test.js
+++ b/test/api_base.test.js
@@ -74,7 +74,7 @@ describe('gdal', function() {
 				var execPath = process.execPath;
 				if (process.platform === 'win32') {
 					//quotes to avoid errors like ''C:\Program' is not recognized as an internal or external command'
-					execPath = '""' + execPath + '"';
+					execPath = '"' + execPath + '"';
 				}
 				cp.exec(execPath + ' ' + ['-e',command].join(' '),{env:{GDAL_DATA:'bogus'}},function(err,stdout,stderr) {
 					if (err) throw err;

--- a/test/api_base.test.js
+++ b/test/api_base.test.js
@@ -73,8 +73,8 @@ describe('gdal', function() {
 				var command = "\"var gdal = require('./lib/gdal.js'); console.log(gdal.config.get('GDAL_DATA'));\"";
 				var execPath = process.execPath;
 				if (process.platform === 'win32') {
-					// attempt to avoid quoting problem that leads to error like ''C:\Program' is not recognized as an internal or external command'
-					execPath = '"' + execPath + '"';
+					//quotes to avoid errors like ''C:\Program' is not recognized as an internal or external command'
+					execPath = '""' + execPath + '"';
 				}
 				cp.exec(execPath + ' ' + ['-e',command].join(' '),{env:{GDAL_DATA:'bogus'}},function(err,stdout,stderr) {
 					if (err) throw err;

--- a/test/api_base.test.js
+++ b/test/api_base.test.js
@@ -71,7 +71,12 @@ describe('gdal', function() {
 				process.env.GDAL_DATA = 'bogus';
 				var cp = require('child_process');
 				var command = "\"var gdal = require('./lib/gdal.js'); console.log(gdal.config.get('GDAL_DATA'));\"";
-				cp.exec(process.execPath + ' ' + ['-e',command].join(' '),{env:{GDAL_DATA:'bogus'}},function(err,stdout,stderr) {
+				var execPath = process.execPath;
+				if (process.platform === 'win32') {
+					// attempt to avoid quoting problem that leads to error like ''C:\Program' is not recognized as an internal or external command'
+					execPath = execPath.replace(/ /g, '\\ ');
+				}
+				cp.exec(execPath + ' ' + ['-e',command].join(' '),{env:{GDAL_DATA:'bogus'}},function(err,stdout,stderr) {
 					if (err) throw err;
 					assert.equal(process.env.GDAL_DATA,stdout.trim());
 					done();


### PR DESCRIPTION
 - If GDAL_DATA environment option is set, respect it
 - If the local data_path does not exist, throw (to prevent odd errors if mistakenly deleted)
 - Add tests for respecting GDAL_DATA environment options
 - Add tests for behavior of using local data by default

/cc @BergWerkGIS 