### PR TITLE
Add minimal code coverage tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ deps/libproj/proj.tar.gz
 deps/libexpat/expat.tar.gz
 lib/binding
 yuidocs
+coverage

--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@ node_modules
 lib/binding
 build
 test
+coverage
 benchmark
 Makefile
 .travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,3 +63,7 @@ script:
   - ./node_modules/.bin/node-pre-gyp package testpackage
   - npm test
   - if [[ "${TARGET}" == "STATIC" && "${PUBLISH_BINARY}" == "true" ]]; then ./node_modules/.bin/node-pre-gyp unpublish publish; rm -rf {build,lib/binding}; ./node_modules/.bin/node-pre-gyp install; npm test; fi
+
+after_script:
+  - npm install coveralls
+  - cat ./coverage/lcov.info | coveralls

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Installs](http://img.shields.io/npm/dm/gdal.svg?style=flat)](https://www.npmjs.org/package/gdal)
 [![Build Status](https://travis-ci.org/naturalatlas/node-gdal.svg)](https://travis-ci.org/naturalatlas/node-gdal)
 [<img src="https://ci.appveyor.com/api/projects/status/mo06c2r5opdwak95?svg=true" height="20" alt="" />](https://ci.appveyor.com/project/brianreavis/node-gdal)
+[![Coverage Status](https://coveralls.io/repos/naturalatlas/node-gdal/badge.svg?branch=master&service=github)](https://coveralls.io/github/naturalatlas/node-gdal?branch=master)
 
 Read and write raster and vector geospatial datasets straight from [Node.js](http://nodejs.org) with this native [GDAL](http://www.gdal.org/) binding. GDAL [2.0.1](http://trac.osgeo.org/gdal/wiki/Release/2.0.1-News) ([GEOS](http://trac.osgeo.org/geos/) [3.4.2](http://trac.osgeo.org/geos/browser/tags/3.4.2/NEWS), [Proj.4](http://trac.osgeo.org/proj/) [4.8.0](http://www.osgeo.org/node/1268)) comes bundled, so node-gdal will work straight out of the box. To get started, browse the [**API Documentation**](http://naturalatlas.github.io/node-gdal/classes/gdal.html) or [examples](examples/).
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "email": "brandon@naturalatlas.com"
   },
   "scripts": {
-    "test": "mocha test -R tap --timeout 600000 --no-colors -gc --require ./test/_common.js",
+    "test": "node --expose_gc ./node_modules/istanbul/lib/cli.js cover _mocha -- test -R tap --timeout 600000 --no-colors --require ./test/_common.js",
     "test-syntax": "eslint lib test --fix",
     "install": "node-pre-gyp install --fallback-to-build",
     "postpublish": "npm run publish-yuidoc",
@@ -53,6 +53,7 @@
     "eslint": "^1.10.1",
     "eslint-config-naturalatlas": "latest",
     "gh-pages": "~0.2.0",
+    "istanbul": "^0.4.1",
     "mocha": "^2.3.4",
     "yuidoc-lucid-theme": "~0.1.1",
     "yuidocjs": "~0.3.50"


### PR DESCRIPTION
`istanbul` and `coverall.io` are great tools for that.

The work-around with `node --expose_gc` is to force GC exposition in tests, as `istanbul` is only compatible with `_mocha` and `_mocha` not provide the `-gc` option.
Should be fixed in the future.

Related to #4 
