### PR TITLE
Include ODBC on Windows

### DIFF
--- a/deps/libgdal/libgdal.gyp
+++ b/deps/libgdal/libgdal.gyp
@@ -172,7 +172,6 @@
 				"gdal/gcore/mdreader/reader_rdk1.cpp",
 				"gdal/gcore/mdreader/reader_spot.cpp",
 
-				# "gdal/port/cpl_odbc.cpp",
 				# "gdal/port/cpl_win32ce_api.cpp",
 				# "gdal/port/vsipreload.cpp",
 				"gdal/port/cpl_worker_thread_pool.cpp",
@@ -297,9 +296,13 @@
 			],
 			"conditions": [
 				["OS == 'win'", {
+					"sources": [
+						"gdal/port/cpl_odbc.cpp"
+					],
 					"link_settings": {
 						"libraries": [
 							"-lws2_32.lib",
+							"-lodbccp32.lib"
 						]
 					}
 				}]


### PR DESCRIPTION
This automatically links ODBC on Windows, which is important for many drivers.

If you build with Visual Studio 2015 you will experience an [incompatibility issue with odbccp32.lib](https://connect.microsoft.com/VisualStudio/feedback/details/1134693/vs-2015-ctp-5-c-vsnwprintf-s-and-other-functions-are-not-exported-in-appcrt140-dll-breaking-linkage-of-static-libraries) (_"unresolved external symbol _vsnwprintf_s"_), which can be fixed by including `"-llegacy_stdio_definitions.lib"` in `libgdal.gyp` as well. (Anyone know how to test for VS 2015 in a .gyp file?)