### PR TITLE
Revert to using bundledDependencies for node-pre-gyp.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "scripts": {
     "test": "mocha test -R tap --timeout 600000 --no-colors -gc --require ./test/_common.js",
     "test-syntax": "eslint lib test --fix",
-    "preinstall":"npm install node-pre-gyp",
     "install": "node-pre-gyp install --fallback-to-build",
     "postpublish": "npm run publish-yuidoc",
     "yuidoc": "yuidoc --extension .js,.cpp,.hpp",
@@ -58,6 +57,9 @@
     "yuidoc-lucid-theme": "~0.1.1",
     "yuidocjs": "~0.3.50"
   },
+  "bundledDependencies": [		
+    "node-pre-gyp"		
+  ],
   "engines": {
     "node": ">= 0.8.0"
   },


### PR DESCRIPTION
As described in the updated node-pre-gyp configuration [doc](https://github.com/mapbox/node-pre-gyp/blob/master/README.md#configuring), revert to bundleDependencies for node-pre-gyp.  Fixes #195