### PR TITLE
Bump node-pre-gyp to 0.6.36

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gdal",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "nan": "~2.6.0",
-    "node-pre-gyp": "~0.6.27"
+    "node-pre-gyp": "^0.6.36"
   },
   "bundledDependencies": [
     "node-pre-gyp"


### PR DESCRIPTION
Fix [yarn](https://yarnpkg.com) support
`~` => `^` change has no effect but had been made by npm

See https://github.com/mapbox/node-pre-gyp/issues/262