### PR TITLE
Update print syntax

### DIFF
--- a/deps/glob-files.py
+++ b/deps/glob-files.py
@@ -16,7 +16,7 @@ import sys
 import glob
 
 if len(sys.argv) < 2:
-  print 'no argument'
+  print('no argument')
   sys.exit(1)
 
 for f in glob.glob(sys.argv[1]):
@@ -25,4 +25,4 @@ for f in glob.glob(sys.argv[1]):
   # as "print" outputs just single backslashes (\) on Windows
   f = f.replace('\\', '/')
   # use line feed as delimiter between file names to prevent problems with whitespaces in file names
-  print f
+  print(f)


### PR DESCRIPTION
Changed the print syntax to `print(<string>)`. 
Because if /usr/bin/python symbolic link is point to python3 the build will fail because the print syntax. With this syntax the script will work with Python 2 and 3. :+1:

Tested with Python 2.7 and Python 3.6 on Arch Linux.