### PR TITLE
Deallocate after use not before when setting gcps

### DIFF
--- a/src/gdal_dataset.cpp
+++ b/src/gdal_dataset.cpp
@@ -583,13 +583,14 @@ NAN_METHOD(Dataset::setGCPs)
 		gcp++;
 	}
 
+	CPLErr err = raw->SetGCPs(gcps->Length(), list, projection.c_str());
+
 	if (list) {
 		delete [] list;
 		delete [] pszId_list;
 		delete [] pszInfo_list;
 	}
 
-	CPLErr err = raw->SetGCPs(gcps->Length(), list, projection.c_str());
 	if (err) {
 		NODE_THROW_CPLERR(err);
 		return;


### PR DESCRIPTION
Currently, list is deallocated and then we try to use it to set gcps. We need to deallocate after setting the gcps, not before.