### PR TITLE
Update rasterband_pixels.cpp

### DIFF
--- a/src/collections/rasterband_pixels.cpp
+++ b/src/collections/rasterband_pixels.cpp
@@ -44,7 +44,7 @@ RasterBandPixels::~RasterBandPixels()
  * Note: Typed arrays should be created with an external ArrayBuffer for versions of node >= 0.11
  * ```
  * var n = 16*16;
- * var data = new Float32Array(new ArrayBuffer(n*4));
+ * var data = new Float32Array(new ArrayBuffer(n));
  * //read data into the existing array
  * band.pixels.read(0,0,16,16,data);```
  *

--- a/src/collections/rasterband_pixels.cpp
+++ b/src/collections/rasterband_pixels.cpp
@@ -43,8 +43,8 @@ RasterBandPixels::~RasterBandPixels()
  * 
  * Note: Typed arrays should be created with an external ArrayBuffer for versions of node >= 0.11
  * ```
- * var n = 16*16;
- * var data = new Float32Array(new ArrayBuffer(n));
+ * var n = 16 * 16;
+ * var data = new Float32Array(new ArrayBuffer(n * 4)); // 4 bytes per float
  * //read data into the existing array
  * band.pixels.read(0,0,16,16,data);```
  *


### PR DESCRIPTION
~the `n*4` makes it seem like we're reading RGBA for each pixel, but experimentally `band.pixels.read(0,0,16,16)` only uses 256 slots in the data buffer; only one elevation reading per pixel.~

oh it's 4 bytes per float